### PR TITLE
[ci] Fix upload path missing -noarch tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           DIST_DIR: mingw64-${{ matrix.arch }}-${{ env.PACKAGE }}-${{ env.PACKAGE_VERSION }}.noarch/dist/mingw64-${{ matrix.arch }}-${{ env.PACKAGE }}
         with:
-          path: ${{ env.DIST_DIR }}/mingw64-${{ matrix.arch }}-${{ env.PACKAGE }}-${{ env.PACKAGE_VERSION }}.tar.xz
+          path: ${{ env.DIST_DIR }}/mingw64-${{ matrix.arch }}-${{ env.PACKAGE }}-${{ env.PACKAGE_VERSION }}-noarch.tar.xz
           name: artifact-${{ matrix.arch }}
           if-no-files-found: error
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           path: ${{ env.DIST_DIR }}/mingw64-${{ matrix.arch }}-${{ env.PACKAGE }}-${{ env.PACKAGE_VERSION }}.tar.xz
           name: artifact-${{ matrix.arch }}
+          if-no-files-found: error
 
   release:
     needs: build


### PR DESCRIPTION
These are now added by default: https://cygwin.com/pipermail/cygwin-announce/2025-March/012238.html

It seems -noarch is added here because mingw packages are used for cross compilation from an arbitrary host machine. Official cygwin mingw packages are also marked as noarch, e.g. https://cygwin.com/packages/summary/mingw64-x86_64-curl.html